### PR TITLE
Optionally allow filtering the alias using a query

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ONBUILD COPY . /index-mapping/
 ONBUILD RUN cd /index-mapping \
   && echo "$(git describe --tag --always 2> /dev/null)" > /mapping.version \
   && cp /index-mapping/mapping.json / \
-  && cp /index-mapping/alias-filter.json / \
+  && if [ -f /index-mapping/alias-filter.json ]; then cp /index-mapping/alias-filter.json / ; fi
   && apk del git \
   && rm -rf /index-mapping
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ ONBUILD COPY . /index-mapping/
 ONBUILD RUN cd /index-mapping \
   && echo "$(git describe --tag --always 2> /dev/null)" > /mapping.version \
   && cp /index-mapping/mapping.json / \
+  && cp /index-mapping/alias-filter.json / \
   && apk del git \
   && rm -rf /index-mapping
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ONBUILD COPY . /index-mapping/
 ONBUILD RUN cd /index-mapping \
   && echo "$(git describe --tag --always 2> /dev/null)" > /mapping.version \
   && cp /index-mapping/mapping.json / \
-  && if [ -f /index-mapping/alias-filter.json ]; then cp /index-mapping/alias-filter.json / ; fi
+  && if [ -f /index-mapping/alias-filter.json ]; then cp /index-mapping/alias-filter.json / ; fi \
   && apk del git \
   && rm -rf /index-mapping
 

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func main() {
 	})
 	aliasFilterFile := app.String(cli.StringOpt{
 		Name:   "alias-filter-file",
-		Value:  "./alias-filter.json",
+		Value:  "",
 		Desc:   "An optional filter query to apply to the alias",
 		EnvVar: "ALIAS_FILTER_FILE",
 	})

--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ func main() {
 		EnvVar: "PANIC_GUIDE_URL",
 	})
 
+	log.SetFormatter(&log.JSONFormatter{})
 	log.SetLevel(log.InfoLevel)
 
 	app.Action = func() {

--- a/main.go
+++ b/main.go
@@ -62,6 +62,12 @@ func main() {
 		Desc:   "Mapping file",
 		EnvVar: "MAPPING_FILE",
 	})
+	aliasFilterFile := app.String(cli.StringOpt{
+		Name:   "alias-filter-file",
+		Value:  "./alias-filter.json",
+		Desc:   "An optional filter query to apply to the alias",
+		EnvVar: "ALIAS_FILTER_FILE",
+	})
 	esTraceLogging := app.Bool(cli.BoolOpt{
 		Name:   "elasticsearch-trace",
 		Value:  false,
@@ -107,7 +113,7 @@ func main() {
 			}
 		}()
 
-		esService := service.NewEsService(ecc, *esIndex, *mappingFile, *mappingVersion, *panicGuideUrl)
+		esService := service.NewEsService(ecc, *esIndex, *mappingFile, *aliasFilterFile, *mappingVersion, *panicGuideUrl)
 		routeRequest(port, esService, *systemCode)
 	}
 

--- a/service/es_service.go
+++ b/service/es_service.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"sync"
 	"time"
 
@@ -238,16 +237,17 @@ func (es *esService) MigrateIndex(aliasName string, mappingFile string, aliasFil
 		}
 	}
 
-	aliasFilter, err := ioutil.ReadFile(aliasFilterFile)
-	if os.IsNotExist(err) {
-		log.Info("alias filter file does not exist; no filter will be applied")
-		aliasFilter = []byte{}
-	} else if err != nil {
-		log.WithError(err).Error("unable to read alias filter")
-		return err
+	var aliasFilter string
+	if len(aliasFilterFile) > 0 {
+		aliasFilterBytes, err := ioutil.ReadFile(aliasFilterFile)
+		if err != nil {
+			log.WithError(err).Error("unable to read alias filter")
+			return err
+		}
+		aliasFilter = string(aliasFilterBytes)
 	}
 
-	err = es.updateAlias(client, aliasName, string(aliasFilter), currentIndexName, newIndexName)
+	err = es.updateAlias(client, aliasName, aliasFilter, currentIndexName, newIndexName)
 	if err != nil {
 		log.WithError(err).Error("failed to update alias")
 		return err

--- a/service/es_service.go
+++ b/service/es_service.go
@@ -17,7 +17,6 @@ import (
 var (
 	ErrNoIndexVersion  error = errors.New("No index version has been specified")
 	ErrNoElasticClient error = errors.New("No ElasticSearch client available")
-	ErrInvalidAlias    error = errors.New("ElasticSearch alias configuration is invalid for update")
 )
 
 type EsService interface {
@@ -266,8 +265,7 @@ func (es *esService) checkIndexAliases(client *elastic.Client, aliasName string)
 		return !(aliasedIndices[0] == requiredIndex), aliasedIndices[0], requiredIndex, nil
 
 	default:
-		log.WithFields(log.Fields{"alias": aliasName, "indices": aliasedIndices}).Error("alias points to multiple indices")
-		return false, "", "", ErrInvalidAlias
+		return false, "", "", fmt.Errorf("alias %s points to multiple indices: %v", aliasName, aliasedIndices)
 	}
 }
 

--- a/service/test/alias-filter.json
+++ b/service/test/alias-filter.json
@@ -1,8 +1,5 @@
 {
-   "terms": {
-      "authorities": [
-         "TME",
-         "SmartLogic"
-      ]
+   "prefix": {
+      "aliases.raw": "Test"
    }
 }

--- a/service/test/alias-filter.json
+++ b/service/test/alias-filter.json
@@ -1,0 +1,8 @@
+{
+   "terms": {
+      "authorities": [
+         "TME",
+         "SmartLogic"
+      ]
+   }
+}


### PR DESCRIPTION
The query is set in an `alias-filter.json` file, and used as-is. 

I couldn't test that the filter gets set because `olivere.elastic` doesn't support it (yet - I might open a PR for them).